### PR TITLE
chore: fix codeowners for workflows dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/metrika-hedera
+/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hashgraph/release-engineering-managers


### PR DESCRIPTION
**Description**:
Resolve the CODEOWNER file so the line reads:

`/.github/workflows/    @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers`

If there are additional owners on the `/.github` folder, that should be declared in a separate line.

**Related issue(s)**:

Fixes #19 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
